### PR TITLE
Fix deprecation warning

### DIFF
--- a/papyri.py
+++ b/papyri.py
@@ -8,7 +8,8 @@ import bedrock.leveldb as leveldb
 from PIL import ImageFont, Image, ImageDraw
 import math
 import operator
-from collections import Callable, defaultdict, OrderedDict, namedtuple
+from collections.abc import Callable
+from collections import defaultdict, OrderedDict, namedtuple
 from tqdm import tqdm
 import argparse
 import gzip


### PR DESCRIPTION
papyri.py:11: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working